### PR TITLE
Ensure config and sensor values are floats

### DIFF
--- a/miflora-card.js
+++ b/miflora-card.js
@@ -132,31 +132,34 @@ class MifloraCard extends HTMLElement {
 
         style.textContent = `
             ha-card {
-            position: relative;
-            padding: 0;
-            background-size: 100%;
+                position: relative;
+                padding: 0;
+                background-size: 100%;
             }
             ha-card .header {
-            width: 100%;
+                width: 100%;
             }
             .image {
                 float: right;
-                margin-left: 8px;
-                margin-right: 8px;
-                margin-bottom: 8px;
-                width: 115px;
-                height: 115px;
+                margin-left: 15px;
+                margin-right: 15px;
+                margin-bottom: 15px;
+                width: 125px;
+                height: 125px;
                 border-radius: 6px;
             }
             .sensor {
-            display: flex;
-            cursor: pointer;
+                display: flex;
+                cursor: pointer;
+                padding-bottom: 10px;
             }
             .icon {
+                margin-left: 10px;
                 color: var(--paper-item-icon-color);
             }
             .name {
                 margin-top: 3px;
+                margin-left: 10px;
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;

--- a/miflora-card.js
+++ b/miflora-card.js
@@ -49,10 +49,10 @@ class MifloraCard extends HTMLElement {
     set hass(hass) {
         const config = this.config;
 
-        var _maxMoisture = config.max_moisture;
-        var _minMoisture = config.min_moisture;
-        var _minConductivity = config.min_conductivity;
-        var _minTemperature = config.min_termperature;
+        var _maxMoisture = parseFloat(config.max_moisture);
+        var _minMoisture = parseFloat(config.min_moisture);
+        var _minConductivity = parseFloat(config.min_conductivity);
+        var _minTemperature = parseFloat(config.min_termperature);
         var _sensors = [];
         for (var i = 0; i < config.entities.length; i++) {
             _sensors.push(config.entities[i].split(":")); // Split name away from sensor id
@@ -70,7 +70,7 @@ class MifloraCard extends HTMLElement {
             var _state = '';
             var _uom = '';
             if (hass.states[_sensor]) {
-                _state = hass.states[_sensor].state;
+                _state = parseFloat(hass.states[_sensor].state);
                 _uom = hass.states[_sensor].attributes.unit_of_measurement || "";
             } else {
                 _state = 'Invalid Sensor';

--- a/miflora-card.js
+++ b/miflora-card.js
@@ -94,7 +94,7 @@ class MifloraCard extends HTMLElement {
                     _alertIcon = '&#9660; ';
                 }
             }
-            if (_name == 'termperature') {
+            if (_name == 'temperature') {
                 if (_state < _minTemperature) {
                     _alertStyle = ';color:red';
                     _alertIcon = '&#9660; ';

--- a/miflora-card.js
+++ b/miflora-card.js
@@ -53,10 +53,6 @@ class MifloraCard extends HTMLElement {
         var _minMoisture = config.min_moisture;
         var _minConductivity = config.min_conductivity;
         var _minTemperature = config.min_termperature;
-        var _sensors = [];
-        for (var i = 0; i < config.entities.length; i++) {
-            _sensors.push(config.entities[i].split(":")); // Split name away from sensor id
-        }
 
         this.shadowRoot.getElementById('container').innerHTML = `
             <div class="content clearfix">
@@ -64,9 +60,14 @@ class MifloraCard extends HTMLElement {
             </div>
             `;
 
-        for (var i = 0; i < _sensors.length; i++) {
-            var _name = _sensors[i][0];
-            var _sensor = _sensors[i][1];
+        for (var i = 0; i < config.entities.length; i++) {
+            var _name = config.entities.[i]['type'];
+            var _sensor = config.entities.[i]['entity'];
+            if (config.entities[i]['name']) {
+                var _display_name = config.entities[i]['name'];
+            } else {
+                var _display_name = _name[0].toUpperCase() + _name.slice(1);
+            }
             var _state = '';
             var _uom = '';
             if (hass.states[_sensor]) {
@@ -103,14 +104,14 @@ class MifloraCard extends HTMLElement {
             this.shadowRoot.getElementById('sensors').innerHTML += `
                 <div id="sensor${i}" class="sensor">
                     <div class="icon"><ha-icon icon="${_icon}"></ha-icon></div>
-                    <div class="name">${_name}</div>
+                    <div class="name">${_display_name}</div>
                     <div class="state" style="${_alertStyle}">${_alertIcon}${_state}${_uom}</div>
                 </div>
                 `
         }
 
-        for (var i = 0; i < _sensors.length; i++) {
-            this.shadowRoot.getElementById('sensor' + [i]).onclick = this._click.bind(this, _sensors[i][1]);
+        for (var i = 0; i < config.entities.length; i++) {
+            this.shadowRoot.getElementById('sensor' + [i]).onclick = this._click.bind(this, config.entities[i]['entity']);
         }
     }
 


### PR DESCRIPTION
In certain conditions, values were interpreted as strings, not floats, which leads to wrong comparisons, and warnings.
Ensuring that we compare floats with floats mitigates this.